### PR TITLE
Make conflict order deterministic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- fix nondeterminism in order of conflicting fields
 
 ## [0.10.3] - 2024-11-17
 ### Fixed

--- a/macro/src/lib.rs
+++ b/macro/src/lib.rs
@@ -460,7 +460,12 @@ impl Conflicts {
     }
 
     fn to_tokens(&self, struct_error: &StructError) -> Result<TokenStream> {
-        self.0
+        let mut conflicts = self.0.iter().collect::<Vec<_>>();
+
+        // The order must be deterministic to be friendly to tools like sccache
+        conflicts.sort();
+
+        conflicts
             .iter()
             .map(|(a, b)| {
                 let af = Formattable::display(&a);


### PR DESCRIPTION
Without this the following struct can be generated in many different ways:

```rust
struct StructFieldAttribute {
    #[attribute(conflicts = [size_fn, ignore])]
    size: Option<usize>,
    #[attribute(conflicts = [size, ignore])]
    size_fn: Option<syn::Ident>,
    #[attribute(conflicts = [size, size_fn])]
    ignore: bool,
}
```

Here's a diff from two consecutive runs of `cargo expand` on it:

```diff
$ diff -rup <(cargo expand) <(cargo expand)
...
--- /dev/fd/63  2025-09-22 19:25:06
+++ /dev/fd/62  2025-09-22 19:25:06
@@ -540,7 +540,7 @@ const _: () = {
             __partial: StructFieldAttributePartial,
         ) -> ::attribute_derive::__private::syn::Result<Self> {
             if let (::core::prelude::v1::Some(__a), ::core::prelude::v1::Some(__b)) = (
-                &__partial.ignore,
+                &__partial.size,
                 &__partial.size_fn,
             ) {
                 if let ::core::prelude::v1::Some(__joined_span) = __a
@@ -550,19 +550,19 @@ const _: () = {
                     return ::core::prelude::v1::Err(
                         ::attribute_derive::__private::syn::Error::new(
                             __joined_span,
-                            "`ignore` conflicts with mutually exclusive `size_fn`",
+                            "`size` conflicts with mutually exclusive `size_fn`",
                         ),
                     );
                 } else {
                     let mut __error = ::attribute_derive::__private::syn::Error::new(
                         __a.error_span(),
-                        "`ignore` conflicts with mutually exclusive `size_fn`",
+                        "`size` conflicts with mutually exclusive `size_fn`",
                     );
                     __error
...
```

This in turn makes it harder for sccache to do its job. Having a sorted vector of conflicts rather than an ordered hashset fixes this problem.